### PR TITLE
Trigger on source change.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -3,6 +3,7 @@ jobs:
   plan:
   - aggregate:
     - get: release-git-repo
+      trigger: true
     - get: pipeline-tasks
     - get: final-builds-dir-tarball
     - get: releases-dir-tarball


### PR DESCRIPTION
I noticed that we're not triggering updates on source change after I merged in a patch from @sharms and we didn't get a new release. Maybe we have a reason not to trigger, but I don't know what it is, so here's this PR.