### PR TITLE
Add no-hostname option to kibana application.

### DIFF
--- a/jobs/push-kibana/spec
+++ b/jobs/push-kibana/spec
@@ -13,6 +13,9 @@ properties:
   push-kibana.app_name:
     description: "The Kibana log dashboard app name ( eg defaults to: logs )"
     default: logs
+  push-kibana.app_no_hostname:
+    description: "Use domain as root of application"
+    default: false
   push-kibana.kibana_index:
     description: "Elasticsearch index to store Kibana settings and dashboards"
     default: ".kibana"

--- a/jobs/push-kibana/templates/config/manifest.yml
+++ b/jobs/push-kibana/templates/config/manifest.yml
@@ -3,6 +3,7 @@ applications:
 - name: <%= p('push-kibana.app_name')%>
   memory: <%= p('push-kibana.app_memory')%>
   instances: <%= p('push-kibana.app_instances')%>
+  no-hostname: <%= p('push-kibana.app_no_hostname')%>
   domain: <%= p('cloudfoundry.apps_domain')%>
   buildpack: binary_buildpack
   command: bash -c "\$HOME/bin/kibana --port \$PORT & pid=\$!; while true; do [ \$(ps uh \$pid | awk '{print \$6}') -gt 300000 ] && { echo memory limit reached, recycling instance; exit 1; }; sleep 1; done"


### PR DESCRIPTION
To handle https://github.com/18F/cg-atlas/issues/133, we're going to use a custom cf domain (logs.cloud.gov) with `no-hostname: true` instead of using the cloud.gov domain with the logs hostname. This patch lets us set `no-hostname` in the manifest from the properties.

@LinuxBozo 