### PR TITLE
Upgrade to es6

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -4,6 +4,7 @@ cf-cli/cf-cli_6.25.0_linux_x86-64.tgz:
   sha: 82728ff9fed87554a14a2e5d2b4b743b8f2885ae
 cf-kibana/kibana-6.3.2-linux-x86_64.tar.gz:
   size: 205331616
+  object_id: df6d8d93-ace3-4a86-7859-b6a8388f3249
   sha: 34ee24fec22fa00a349a1fd1cda3855b3432a08a
 redis/redis-3.2.9.tar.gz:
   size: 1547695

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,9 @@ cf-cli/cf-cli_6.25.0_linux_x86-64.tgz:
   size: 5088758
   object_id: 4316161b-3625-4eb3-97a7-6631de9360f2
   sha: 82728ff9fed87554a14a2e5d2b4b743b8f2885ae
-cf-kibana/kibana-5.6.4-linux-x86_64.tar.gz:
-  size: 51834711
-  object_id: d5097eeb-0aa6-40f4-76f3-6d353999ac88
-  sha: 1a331c46a878d7b1adfbb80834f7ab8d971e6872
+cf-kibana/kibana-6.3.2-linux-x86_64.tar.gz:
+  size: 205331616
+  sha: 34ee24fec22fa00a349a1fd1cda3855b3432a08a
 redis/redis-3.2.9.tar.gz:
   size: 1547695
   object_id: a1230536-4203-40b9-97e1-9f11d470308d

--- a/jobs/cf-kibana/spec
+++ b/jobs/cf-kibana/spec
@@ -98,6 +98,9 @@ properties:
   cf-kibana.grokdebugger_enabled:
     description: "Enable Kibana development grok debugger; should be set to `false` in a multi-tenant deployment."
     default: false
+  cf-kibana.apm_enabled:
+    description: "Enable Kibana APM ui; should be set to `false` in a multi-tenant deployment."
+    default: false
   cf-kibana.config_options:
     description: "Additional options to append to kibana configuration (YAML format)."
     default: ~

--- a/jobs/cf-kibana/spec
+++ b/jobs/cf-kibana/spec
@@ -92,6 +92,12 @@ properties:
   cf-kibana.console_enabled:
     description: "Enable Kibana development console; should be set to `false` in a multi-tenant deployment."
     default: false
+  cf-kibana.searchprofiler_enabled:
+    description: "Enable Kibana development search profiler; should be set to `false` in a multi-tenant deployment."
+    default: false
+  cf-kibana.grokdebugger_enabled:
+    description: "Enable Kibana development grok debugger; should be set to `false` in a multi-tenant deployment."
+    default: false
   cf-kibana.config_options:
     description: "Additional options to append to kibana configuration (YAML format)."
     default: ~

--- a/jobs/cf-kibana/templates/kibana.yml.erb
+++ b/jobs/cf-kibana/templates/kibana.yml.erb
@@ -103,7 +103,7 @@ xpack.searchprofiler.enabled: <%= p("cf-kibana.searchprofiler_enabled") %>
 xpack.grokdebugger.enabled: <%= p("cf-kibana.grokdebugger_enabled") %>
 
 # disable apm
-xpack.apm.ui.enabled: <%= p("cf-kibana.grokdebugger_enabled") %>
+xpack.apm.ui.enabled: <%= p("cf-kibana.apm_enabled") %>
 
 # disable x-pack
 xpack.monitoring.enabled: false

--- a/jobs/cf-kibana/templates/kibana.yml.erb
+++ b/jobs/cf-kibana/templates/kibana.yml.erb
@@ -99,9 +99,14 @@ logging.quiet: <%= p("cf-kibana.logging_quiet") %>
 
 # Configure development console
 console.enabled: <%= p("cf-kibana.console_enabled") %>
+xpack.searchprofiler.enabled: <%= p("cf-kibana.searchprofiler_enabled") %>
+xpack.grokdebugger.enabled: <%= p("cf-kibana.grokdebugger_enabled") %>
+
+# disable apm
+xpack.apm.ui.enabled: <%= p("cf-kibana.grokdebugger_enabled") %>
 
 # disable x-pack
-xpack.monitoring.enabled: true
+xpack.monitoring.enabled: false
 xpack.graph.enabled: false
 xpack.ml.enabled: false
 xpack.security.enabled: false

--- a/jobs/cf-kibana/templates/kibana.yml.erb
+++ b/jobs/cf-kibana/templates/kibana.yml.erb
@@ -100,4 +100,11 @@ logging.quiet: <%= p("cf-kibana.logging_quiet") %>
 # Configure development console
 console.enabled: <%= p("cf-kibana.console_enabled") %>
 
+# disable x-pack
+xpack.monitoring.enabled: true
+xpack.graph.enabled: false
+xpack.ml.enabled: false
+xpack.security.enabled: false
+xpack.watcher.enabled: false
+
 <% if_p('cf-kibana.config_options') do | v | %><%= v %><% end %>

--- a/jobs/cf-kibana/templates/kibana.yml.erb
+++ b/jobs/cf-kibana/templates/kibana.yml.erb
@@ -102,7 +102,7 @@ console.enabled: <%= p("cf-kibana.console_enabled") %>
 xpack.searchprofiler.enabled: <%= p("cf-kibana.searchprofiler_enabled") %>
 xpack.grokdebugger.enabled: <%= p("cf-kibana.grokdebugger_enabled") %>
 
-# disable apm
+# configure apm
 xpack.apm.ui.enabled: <%= p("cf-kibana.apm_enabled") %>
 
 # disable x-pack

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings-app.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings-app.json.erb
@@ -1,12 +1,10 @@
 <%
 # This file contains mappings specific for 'app' indicies.
 #
-# By default all string fields are set as `not_analyzed`.
-#
 
 require 'json'
 
-string_default = { "type": "string", "index": "not_analyzed" }.to_json
+string_default = { "type": "keyword", "index": true }.to_json
 
 %>
 {
@@ -15,7 +13,7 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
   "order": 203,
   "mappings" : {
     <%# ------------ App specific types %>
-    "LogMessage": {
+    "_default_": {
       "properties": {
         "@cf": {
           "type": "object",
@@ -30,7 +28,7 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
             "space_id":     <%= string_default %>
           }
         },
-        "logmessage": {
+        "LogMessage": {
           "type": "object",
           "dynamic": true,
           "properties": {
@@ -89,26 +87,9 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
             "location": { "type": "geo_point" },
             "timezone": <%= string_default %>
           }
-        }
-      }
-    },
-
-    "ContainerMetric": {
-      "properties": {
-        "@cf": {
-          "type": "object",
-          "dynamic": true,
-          "properties": {
-            "app":          <%= string_default %>,
-            "app_id":       <%= string_default %>,
-            "app_instance": { "type": "long" },
-            "org":          <%= string_default %>,
-            "org_id":       <%= string_default %>,
-            "space":        <%= string_default %>,
-            "space_id":     <%= string_default %>
-          }
         },
-        "containermetric": {
+
+        "ContainerMetric": {
           "type": "object",
           "dynamic": true,
           "properties": {
@@ -118,13 +99,9 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
             "disk_bytes":         { "type": "long" },
             "cpu_percentage":     { "type": "scaled_float", "scaling_factor": 100 }
           }
-        }
-      }
-    },
+        },
 
-    "ValueMetric": {
-      "properties": {
-        "valuemetric": {
+        "ValueMetric": {
           "type": "object",
           "dynamic": true,
           "properties": {
@@ -132,13 +109,9 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
             "name":  <%= string_default %>,
             "value": { "type": "long" }
           }
-        }
-      }
-    },
+        },
 
-    "CounterEvent": {
-      "properties": {
-        "counterevent": {
+        "CounterEvent": {
           "type": "object",
           "dynamic": true,
           "properties": {
@@ -146,39 +119,18 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
             "name":  <%= string_default %>,
             "total": { "type": "long" }
           }
-        }
-      }
-    },
+        },
 
-    "Error": {
-      "properties": {
-        "error": {
+        "Error": {
           "type": "object",
           "dynamic": true,
           "properties": {
             "source":  <%= string_default %>,
             "code": { "type": "long" }
           }
-        }
-      }
-    },
-
-    "HttpStartStop": {
-      "properties": {
-        "@cf": {
-          "type": "object",
-          "dynamic": true,
-          "properties": {
-            "app":          <%= string_default %>,
-            "app_id":       <%= string_default %>,
-            "app_instance": { "type": "long" },
-            "org":          <%= string_default %>,
-            "org_id":       <%= string_default %>,
-            "space":        <%= string_default %>,
-            "space_id":     <%= string_default %>
-          }
         },
-        "httpstartstop": {
+
+        "HttpStartStop": {
           "type": "object",
           "dynamic": true,
           "properties": {

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings-app.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings-app.json.erb
@@ -13,7 +13,7 @@ string_default = { "type": "keyword", "index": true }.to_json
   "order": 203,
   "mappings" : {
     <%# ------------ App specific types %>
-    "_default_": {
+    "_doc": {
       "properties": {
         "@cf": {
           "type": "object",

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings-app.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings-app.json.erb
@@ -13,7 +13,7 @@ string_default = { "type": "keyword", "index": true }.to_json
   "order": 203,
   "mappings" : {
     <%# ------------ App specific types %>
-    "_doc": {
+    "doc": {
       "properties": {
         "@cf": {
           "type": "object",

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings-platform.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings-platform.json.erb
@@ -16,7 +16,7 @@ string_default = { "type": "keyword", "index": true }.to_json
   "order": 204,
   "mappings" : {
     <%# ------------ Platform specific types %>
-    "_doc": {
+    "doc": {
       "properties": {
         "geoip"  : {
           "type" : "object",

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings-platform.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings-platform.json.erb
@@ -16,7 +16,7 @@ string_default = { "type": "keyword", "index": true }.to_json
   "order": 204,
   "mappings" : {
     <%# ------------ Platform specific types %>
-    "_default_": {
+    "_doc": {
       "properties": {
         "geoip"  : {
           "type" : "object",

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings-platform.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings-platform.json.erb
@@ -7,7 +7,7 @@
 require 'json'
 
 
-string_default = { "type": "string", "index": "not_analyzed" }.to_json
+string_default = { "type": "keyword", "index": true }.to_json
 
 %>
 {
@@ -24,12 +24,8 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
           "properties" : {
             "location" : { "type" : "geo_point" }
           }
-        }
-      }
-    },
+        },
 
-    "uaa": {
-      "properties": {
         "uaa": {
           "type": "object",
           "dynamic": true,
@@ -51,12 +47,8 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
               }
             }
           }
-        }
-      }
-    },
+        },
 
-    "haproxy": {
-      "properties": {
         "haproxy": {
           "type": "object",
           "dynamic": true,

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings.json.erb
@@ -32,7 +32,7 @@ full_text_with_raw_copy = {
   "order": 202,
   "mappings" : {
     <%# --------------  Default type (applied to all types) %>
-    "_doc" : {
+    "doc" : {
       "properties" : {
 
          <%# ------  common fields %>

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings.json.erb
@@ -32,7 +32,7 @@ full_text_with_raw_copy = {
   "order": 202,
   "mappings" : {
     <%# --------------  Default type (applied to all types) %>
-    "_default_" : {
+    "_doc" : {
       "properties" : {
 
          <%# ------  common fields %>

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings.json.erb
@@ -9,16 +9,16 @@
 require 'json'
 
 
-string_default = { "type": "string", "index": "not_analyzed" }.to_json
+string_default = { "type": "keyword", "index": true }.to_json
 
 full_text_with_raw_copy = {
-  "type": "string",
-  "index": "analyzed",
-  "norms": { "enabled": false },
+  "type": "text",
+  "index": true,
+  "norms": false,
   "fields": {
     "raw": {
-      "type": "string",
-      "index": "not_analyzed",
+      "type": "keyword",
+      "index": true,
       "ignore_above": 256
     }
   }

--- a/jobs/upload-kibana-objects/spec
+++ b/jobs/upload-kibana-objects/spec
@@ -22,6 +22,7 @@ templates:
   kibana-objects/config/4.4.0.json.erb:  kibana-objects/config/4.4.0.json
   kibana-objects/config/4.4.2.json.erb:  kibana-objects/config/4.4.2.json
   kibana-objects/config/4.5.4.json.erb:  kibana-objects/config/4.5.4.json
+  kibana-objects/config/6.3.2.json.erb:  kibana-objects/config/6.3.2.json
 
   kibana-objects/search/app-all.json.erb:                         kibana-objects/search/app-all.json
   kibana-objects/search/app-all-messages.json.erb:                kibana-objects/search/app-all-messages.json

--- a/jobs/upload-kibana-objects/templates/bin/run
+++ b/jobs/upload-kibana-objects/templates/bin/run
@@ -43,8 +43,8 @@ def render_upsert_queries(type, pattern)
       else
         id = File.basename(data_file, ".json")
       end
-      combined += "{\"delete\":{\"_index\":\".kibana\",\"_type\":\"#{type}\",\"_id\":\"#{id}\"}}\n"
-      combined += "{\"index\":{\"_index\":\".kibana\",\"_type\":\"#{type}\",\"_id\":\"#{id}\"}}\n"
+      combined += "{\"delete\":{\"_index\":\".kibana\",\"_type\":\"_doc\",\"_id\":\"#{id}\"}}\n"
+      combined += "{\"index\":{\"_index\":\".kibana\",\"_type\":\"_doc\",\"_id\":\"#{id}\"}}\n"
       combined += "#{parsed_json.to_json}\n"
       log_status("#{data_file}")
     rescue StandardError => err

--- a/jobs/upload-kibana-objects/templates/bin/run
+++ b/jobs/upload-kibana-objects/templates/bin/run
@@ -123,7 +123,7 @@ $logger.info("Defaults data to upload:\n#{upload_data}")
   end
 %>
 
-result = `curl http://<%= elasticsearch_host %>:<%= elasticsearch_port %>/_bulk -d '#{upload_data.to_s}'`
+result = `curl -H 'Content-Type: application/json' http://<%= elasticsearch_host %>:<%= elasticsearch_port %>/_bulk -d '#{upload_data.to_s}'`
 log_status("=======")
 $logger.info("======= Result of uploading defaults: #{result}")
 puts("======= Result of uploading defaults: #{process_bulk_query_result(result)}")
@@ -138,8 +138,8 @@ log_status("--------------------------------------------------")
 log_status("======= Files to upload:")
 <% p("kibana_objects.upload_data_files").each do |object| %>
 log_status("<%= object %>")
-result = `cat <%= object %> | curl --data-binary @- http://<%= elasticsearch_host %>:<%= elasticsearch_port %>/_bulk`
+result = `cat <%= object %> | curl -H 'Content-Type: application/json' --data-binary @- http://<%= elasticsearch_host %>:<%= elasticsearch_port %>/_bulk`
 $logger.info("======= Result of uploading '<%= object %>': #{result}")
 puts "======= Result of uploading '<%= object %>': #{process_bulk_query_result(result)}"
-<% end if ! p("kibana_objects.upload_data_files").nil? %>
+<% end %>
 log_status("=======")

--- a/jobs/upload-kibana-objects/templates/bin/run
+++ b/jobs/upload-kibana-objects/templates/bin/run
@@ -141,5 +141,5 @@ log_status("<%= object %>")
 result = `cat <%= object %> | curl --data-binary @- http://<%= elasticsearch_host %>:<%= elasticsearch_port %>/_bulk`
 $logger.info("======= Result of uploading '<%= object %>': #{result}")
 puts "======= Result of uploading '<%= object %>': #{process_bulk_query_result(result)}"
-<% end if ! kibana_objects.upload_data_files.nil? %>
+<% end if ! p("kibana_objects.upload_data_files").nil? %>
 log_status("=======")

--- a/jobs/upload-kibana-objects/templates/bin/run
+++ b/jobs/upload-kibana-objects/templates/bin/run
@@ -44,7 +44,7 @@ def render_upsert_queries(type, pattern)
       else
         id = File.basename(data_file, ".json")
       end
-      now = DateTime.new.strftime('%Y-%m-%dT%H:%M:%S.%LZ')
+      now = DateTime.now.strftime('%Y-%m-%dT%H:%M:%S.%LZ')
       combined += "{\"delete\":{\"_index\":\".kibana\",\"_type\":\"doc\",\"_id\":\"#{id}\"}}\n"
       combined += "{\"index\":{\"_index\":\".kibana\",\"_type\":\"doc\",\"_id\":\"#{id}\"}}\n"
       combined += "{\"updated_at\": \"#{now}\", \"type\": \"#{type}\",\"#{type}\":#{parsed_json.to_json}}\n"

--- a/jobs/upload-kibana-objects/templates/bin/run
+++ b/jobs/upload-kibana-objects/templates/bin/run
@@ -45,8 +45,8 @@ def render_upsert_queries(type, pattern)
         id = File.basename(data_file, ".json")
       end
       now = DateTime.now.strftime('%Y-%m-%dT%H:%M:%S.%LZ')
-      combined += "{\"delete\":{\"_index\":\".kibana\",\"_type\":\"doc\",\"_id\":\"#{id}\"}}\n"
-      combined += "{\"index\":{\"_index\":\".kibana\",\"_type\":\"doc\",\"_id\":\"#{id}\"}}\n"
+      combined += "{\"delete\":{\"_index\":\".kibana\",\"_type\":\"doc\",\"_id\":\"#{type}:#{id}\"}}\n"
+      combined += "{\"index\":{\"_index\":\".kibana\",\"_type\":\"doc\",\"_id\":\"{type}:#{id}\"}}\n"
       combined += "{\"updated_at\": \"#{now}\", \"type\": \"#{type}\",\"#{type}\":#{parsed_json.to_json}}\n"
       log_status("#{data_file}")
     rescue StandardError => err

--- a/jobs/upload-kibana-objects/templates/bin/run
+++ b/jobs/upload-kibana-objects/templates/bin/run
@@ -141,5 +141,5 @@ log_status("<%= object %>")
 result = `cat <%= object %> | curl --data-binary @- http://<%= elasticsearch_host %>:<%= elasticsearch_port %>/_bulk`
 $logger.info("======= Result of uploading '<%= object %>': #{result}")
 puts "======= Result of uploading '<%= object %>': #{process_bulk_query_result(result)}"
-<% end %>
+<% end if ! kibana_objects.upload_data_files.nil? %>
 log_status("=======")

--- a/jobs/upload-kibana-objects/templates/bin/run
+++ b/jobs/upload-kibana-objects/templates/bin/run
@@ -43,8 +43,8 @@ def render_upsert_queries(type, pattern)
       else
         id = File.basename(data_file, ".json")
       end
-      combined += "{\"delete\":{\"_index\":\".kibana\",\"_type\":\"_doc\",\"_id\":\"#{id}\"}}\n"
-      combined += "{\"index\":{\"_index\":\".kibana\",\"_type\":\"_doc\",\"_id\":\"#{id}\"}}\n"
+      combined += "{\"delete\":{\"_index\":\".kibana\",\"_type\":\"doc\",\"_id\":\"#{id}\"}}\n"
+      combined += "{\"index\":{\"_index\":\".kibana\",\"_type\":\"doc\",\"_id\":\"#{id}\"}}\n"
       combined += "#{parsed_json.to_json}\n"
       log_status("#{data_file}")
     rescue StandardError => err

--- a/jobs/upload-kibana-objects/templates/bin/run
+++ b/jobs/upload-kibana-objects/templates/bin/run
@@ -24,6 +24,7 @@ log_status("Upload Kibana objects from job defaults. Start processing...")
 log_status("------------------------------------------------------------")
 
 require 'json'
+require 'date'
 
 def render_upsert_queries(type, pattern)
   combined = ""
@@ -43,9 +44,10 @@ def render_upsert_queries(type, pattern)
       else
         id = File.basename(data_file, ".json")
       end
+      now = DateTime.new.strftime('%Y-%m-%dT%H:%M:%S.%LZ')
       combined += "{\"delete\":{\"_index\":\".kibana\",\"_type\":\"doc\",\"_id\":\"#{id}\"}}\n"
       combined += "{\"index\":{\"_index\":\".kibana\",\"_type\":\"doc\",\"_id\":\"#{id}\"}}\n"
-      combined += "#{parsed_json.to_json}\n"
+      combined += "{\"updated_at\": \"#{now}\", \"type\": \"#{type}\",\"#{type}\":#{parsed_json.to_json}}\n"
       log_status("#{data_file}")
     rescue StandardError => err
       # skip

--- a/jobs/upload-kibana-objects/templates/bin/run
+++ b/jobs/upload-kibana-objects/templates/bin/run
@@ -46,7 +46,7 @@ def render_upsert_queries(type, pattern)
       end
       now = DateTime.now.strftime('%Y-%m-%dT%H:%M:%S.%LZ')
       combined += "{\"delete\":{\"_index\":\".kibana\",\"_type\":\"doc\",\"_id\":\"#{type}:#{id}\"}}\n"
-      combined += "{\"index\":{\"_index\":\".kibana\",\"_type\":\"doc\",\"_id\":\"{type}:#{id}\"}}\n"
+      combined += "{\"index\":{\"_index\":\".kibana\",\"_type\":\"doc\",\"_id\":\"#{type}:#{id}\"}}\n"
       combined += "{\"updated_at\": \"#{now}\", \"type\": \"#{type}\",\"#{type}\":#{parsed_json.to_json}}\n"
       log_status("#{data_file}")
     rescue StandardError => err

--- a/jobs/upload-kibana-objects/templates/kibana-objects/config/6.3.2.json.erb
+++ b/jobs/upload-kibana-objects/templates/kibana-objects/config/6.3.2.json.erb
@@ -1,0 +1,5 @@
+{
+  "defaultIndex": "<%= p('elasticsearch_config.app_index_prefix') %>*",
+  "telemetry:optIn": false,
+  "buildNum": 17307
+}

--- a/packages/cf-kibana/packaging
+++ b/packages/cf-kibana/packaging
@@ -1,6 +1,6 @@
 set -e
 
-tar xzf cf-kibana/kibana-5.6.4-linux-x86_64.tar.gz --strip 1 -C ${BOSH_INSTALL_TARGET}
+tar xzf cf-kibana/kibana-6.3.2-linux-x86_64.tar.gz --strip 1 -C ${BOSH_INSTALL_TARGET}
 
 cd ${BOSH_INSTALL_TARGET}
 bin/kibana-plugin install file:///var/vcap/packages/kibana-auth-plugin/kibana-auth-plugin.zip

--- a/packages/cf-kibana/spec
+++ b/packages/cf-kibana/spec
@@ -5,4 +5,4 @@ dependencies:
   - kibana-auth-plugin
 
 files:
-  - cf-kibana/kibana-5.6.4-linux-x86_64.tar.gz
+  - cf-kibana/kibana-6.3.2-linux-x86_64.tar.gz

--- a/src/kibana-cf_authentication/package.json
+++ b/src/kibana-cf_authentication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authentication",
-  "version": "5.6.9",
+  "version": "6.3.2",
   "description": "Integrations Kibana into CF's OAuth 2 authentication mechanism + User page in Kibana",
   "repository": {
     "type": "git",


### PR DESCRIPTION
change types and mappings and kibana config to work with ES6, update to ES6, etc.

This goes with https://github.com/18F/logsearch-boshrelease/pull/6

Make sure that https://github.com/18F/cg-deploy-logsearch/pull/141 is merged first, so that the proper logsearch-platform default index pattern is selected.