### PR TITLE
logstash contained a dependency on the old version of ruby.

### DIFF
--- a/packages/logsearch-config-logstash-filters/spec
+++ b/packages/logsearch-config-logstash-filters/spec
@@ -2,7 +2,7 @@
 name: logsearch-config-logstash-filters
 
 dependencies:
-  - ruby-2.4-r5
+  - ruby-2.4.6-r0.16.0
 
 files:
   - logsearch-config/*


### PR DESCRIPTION
Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>