### PR TITLE
Create and use a package for the python deps of upload-kibana-objects

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,6 +10,22 @@ redis/redis-3.2.9.tar.gz:
   size: 1547695
   object_id: a1230536-4203-40b9-97e1-9f11d470308d
   sha: 8fad759f28bcb14b94254124d824f1f3ed7b6aa6
+request/urllib3-1.25.8.whl:
+  size: 125642
+  object_id: f049c5a4-5d06-45fb-7c76-455326004ef9
+  sha: sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc
+requests/certifi-2019.11.28.whl:
+  size: 156030
+  object_id: 6fe9537e-c003-427e-77a6-e06e97a3558e
+  sha: sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3
+requests/chardet-3.0.4.whl:
+  size: 133356
+  object_id: a05da880-3a49-414c-4d36-8dad9fd792e2
+  sha: sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
+requests/idna-2.8.whl:
+  size: 58594
+  object_id: 617e3848-23da-4939-5ae6-7fbddcc5c410
+  sha: sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c
 requests/requests-2.22.0.whl:
   size: 57952
   object_id: 2e48a6af-17cf-4a0c-5a47-b298ef16e853

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,6 +10,10 @@ redis/redis-3.2.9.tar.gz:
   size: 1547695
   object_id: a1230536-4203-40b9-97e1-9f11d470308d
   sha: 8fad759f28bcb14b94254124d824f1f3ed7b6aa6
+requests/requests-2.22.0.whl:
+  size: 57952
+  object_id: 2e48a6af-17cf-4a0c-5a47-b298ef16e853
+  sha: sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31
 ruby/rake-12.3.2.gem:
   size: 87040
   object_id: eb36ff1c-24a2-4291-605c-96f37985481f

--- a/jobs/upload-kibana-objects/spec
+++ b/jobs/upload-kibana-objects/spec
@@ -5,6 +5,8 @@ description: This job uploads Kibana saved objects (index-patterns, searches, vi
 
 packages:
 - ruby-2.4.6-r0.16.0
+- python3
+- upload-kibana-objects-python3
 
 consumes:
 - name: elasticsearch

--- a/jobs/upload-kibana-objects/templates/bin/import-objects
+++ b/jobs/upload-kibana-objects/templates/bin/import-objects
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/var/vcap/packages/upload-kibana-objects-python3/bin/python3
 
 <%
   system_domain = nil

--- a/packages/upload-kibana-objects-python3/packaging
+++ b/packages/upload-kibana-objects-python3/packaging
@@ -1,0 +1,5 @@
+set -e
+
+${BOSH_INSTALL_TARGET}/../python3/bin/python3 -m venv ${BOSH_INSTALL_TARGET}
+
+${BOSH_INSTALL_TARGET}/bin/python3 -m pip install --no-index requests/requests-2.22.0.whl

--- a/packages/upload-kibana-objects-python3/packaging
+++ b/packages/upload-kibana-objects-python3/packaging
@@ -2,4 +2,4 @@ set -e
 
 ${BOSH_INSTALL_TARGET}/../python3/bin/python3 -m venv ${BOSH_INSTALL_TARGET}
 
-${BOSH_INSTALL_TARGET}/bin/python3 -m pip install --no-index requests/requests-2.22.0.whl
+${BOSH_INSTALL_TARGET}/bin/python3 -m pip install --no-index requests/*.whl

--- a/packages/upload-kibana-objects-python3/spec
+++ b/packages/upload-kibana-objects-python3/spec
@@ -1,0 +1,8 @@
+---
+name: upload-kibana-objects-python3
+
+dependencies:
+- python3
+
+files:
+- requests/*

--- a/packages/upload-kibana-objects-python3/spec
+++ b/packages/upload-kibana-objects-python3/spec
@@ -1,5 +1,11 @@
 ---
+# this package installs all the requirements of the upload-kibana-objects
+# into a python virtual environment. 
+#
+# To update this run `python3 -m pip download requests` then bosh add-blob each of the wheels
+
 name: upload-kibana-objects-python3
+
 
 dependencies:
 - python3


### PR DESCRIPTION
## Changes Proposed

- Add a package that bundles the python packages needed for upload-kibana-objects
- use that package

This should fix the `upload-kibana-objects` job in the tenant logsearch instances

## Security Considerations
Since we are vendoring python pakages now, we'll need to keep an eye on their CVEs
