### PR TITLE
set path explicitly

### DIFF
--- a/packages/upload-kibana-objects-python3/packaging
+++ b/packages/upload-kibana-objects-python3/packaging
@@ -1,5 +1,5 @@
 set -e
 
-${BOSH_INSTALL_TARGET}/../python3/bin/python3 -m venv ${BOSH_INSTALL_TARGET}
+/var/vcap/packages/python3/bin/python3 -m venv ${BOSH_INSTALL_TARGET}
 
 ${BOSH_INSTALL_TARGET}/bin/python3 -m pip install --no-index requests/*.whl


### PR DESCRIPTION
## Changes Proposed

- Set the python path explicitly, rather than basing it on `BOSH_INSTALL_TARGET`

## Security Considerations
None