### PR TITLE
Update import-objects to attach on the backend

### DIFF
--- a/jobs/upload-kibana-objects/spec
+++ b/jobs/upload-kibana-objects/spec
@@ -106,7 +106,7 @@ properties:
     default: []
   kibana_objects.default_index:
     description: "Default index to set in Kibana"
-    default: "logs-app*"
+    default: "logs-platform*"
   kibana_objects.host_name:
     description: the host-portion of the FQDN kibana is served from, without the domain name
     default: logs
@@ -142,3 +142,9 @@ properties:
     description: |
       Name prefix of your `platform` log indices. If you don't split `app` and `platform` indices, then just set it with the value of `elasticsearch_config.index_prefix`.
     default: "logs-platform"
+  kibana_ip:
+    description: ip address of one of the kibana nodes needed for upload-kibana-objects script
+    default: kibana.logsearch-platform.internal
+  kibana_port:
+    description: port kibana is listening on (not oauth-proxy's port)
+    default: 5602

--- a/jobs/upload-kibana-objects/templates/bin/import-objects
+++ b/jobs/upload-kibana-objects/templates/bin/import-objects
@@ -23,31 +23,16 @@ logging.basicConfig(level=logging.INFO)
 if __name__ == "__main__":
     session = requests.Session()
 
-    logs = session.get('https://<%= logs_hostname %>.<%= system_domain %>'<% if p("cloudfoundry.skip_ssl_validation") %>, verify=False<% end %>)
-    assert logs.url == 'https://login.<%= system_domain %>/login', logs.url
-    assert logs.status_code == 200, logs.status_code
-
-    login = session.post(
-        'https://<%= p("kibana_objects.login_host_name") %>.<%= system_domain %>/login.do',
-        data={
-            'username': '<%= p('cloudfoundry.user') %>',
-            'password': '<%= p('cloudfoundry.password') %>',
-            'X-Uaa-Csrf': logs.cookies['X-Uaa-Csrf'],
-        },
-    )
-    assert login.url == 'https://<%= logs_hostname %>.<%= system_domain %>/app/home', login.url
-    assert login.status_code == 200, login.status_code
-
     for filename in glob.iglob('/var/vcap/jobs/upload-kibana-objects/kibana-objects/**/*.json', recursive=True):
         headers = {'content-type': 'application/json', 'kbn-xsrf': 'true'}
         r = session.post(
-                'https://<%= logs_hostname %>.<%= system_domain %>/api/saved_objects/{}/{}'.format(os.path.basename(os.path.dirname(filename)), os.path.basename(os.path.splitext(filename)[0])),
+                'http://<%= kibana_ip %>:<%= kibana_port %>/api/saved_objects/{}/{}'.format(os.path.basename(os.path.dirname(filename)), os.path.basename(os.path.splitext(filename)[0])),
                 data=open(filename, 'rb'),
                 headers=headers
         )
         if r.status_code == 409:
             put = session.put(
-                    'https://<%= logs_hostname %>.<%= system_domain %>/api/saved_objects/{}/{}'.format(os.path.basename(os.path.dirname(filename)), os.path.basename(os.path.splitext(filename)[0])),
+                    'http://<%= kibana_ip %>:<%= kibana_port %>/api/saved_objects/{}/{}'.format(os.path.basename(os.path.dirname(filename)), os.path.basename(os.path.splitext(filename)[0])),
                     data=open(filename, 'rb'),
                     headers=headers
             )
@@ -61,7 +46,7 @@ if __name__ == "__main__":
             logging.info('Object %s Failed to Upload', filename)
 
     r = session.post(
-      'https://<%= logs_hostname %>.<%= system_domain %>/api/kibana/settings',
+      'http://<%= kibana_ip %>:<%= kibana_port %>/api/kibana/settings',
       data='{"changes":{"defaultIndex":"<%= p('kibana_objects.default_index') %>"}}',
       headers=headers
     )


### PR DESCRIPTION
## Changes Proposed

- Should be part of fix for a 5+ year broken uploading of kibana objects, instead of routing through the load balancer and oauth-proxy getting in the way, runs the script against the kibana node from the maintenance node since all that is needed is ip and port.
- Changing the default_index default value to one which actually exists for logsearch-platform.  Tenant logs are moved to opensearch.
- The value for `kibana.logsearch-platform.internal` will be set with a bosh-dns-alias configuration in the deployment manifest.  There will be a separate PR for that shortly, tested manually via ops file in staging.
- The script is run as part of an bosh errand because of the presence of `bin/run` defined for the job.  Will likely define the execution of this as part of the ci pipeline in the deployment repo.
- Part of https://github.com/cloud-gov/deploy-logsearch/issues/203

## Security Considerations

No additional passwords or changes to networking.  Updates a script to use bosh-dns controlled ips instead of system_url definitions.
