### PR TITLE
Add id field configuration to index patterns

### DIFF
--- a/jobs/upload-kibana-objects/templates/kibana-objects/index-pattern/logs-app.json.erb
+++ b/jobs/upload-kibana-objects/templates/kibana-objects/index-pattern/logs-app.json.erb
@@ -175,5 +175,7 @@ end
     "title": "<%= p('elasticsearch_config.app_index_prefix') %>*",
     "timeFieldName": "@timestamp",
     "fields": "<%= fields_json.to_json.gsub(/\\/, '\\\\').gsub(/"/, '\"') %>"
-  }
+  },
+  "id": "<%= p('elasticsearch_config.app_index_prefix') %>*",
+  "type":"index-pattern"
 }

--- a/jobs/upload-kibana-objects/templates/kibana-objects/index-pattern/logs-platform.json.erb
+++ b/jobs/upload-kibana-objects/templates/kibana-objects/index-pattern/logs-platform.json.erb
@@ -100,5 +100,7 @@ fields_json.concat(
     "title": "<%= p('elasticsearch_config.platform_index_prefix') %>*",
     "timeFieldName": "@timestamp",
     "fields": "<%= fields_json.to_json.gsub(/\\/, '\\\\').gsub(/"/, '\"') %>"
-  }
+  },
+  "id": "<%= p('elasticsearch_config.platform_index_prefix') %>*",
+  "type":"index-pattern"
 }

--- a/jobs/upload-kibana-objects/templates/kibana-objects/index-pattern/logs.json.erb
+++ b/jobs/upload-kibana-objects/templates/kibana-objects/index-pattern/logs.json.erb
@@ -231,5 +231,7 @@ end
     "title": "<%= p('elasticsearch_config.index_prefix') %>*",
     "timeFieldName": "@timestamp",
     "fields": "<%= fields_json.to_json.gsub(/\\/, '\\\\').gsub(/"/, '\"') %>"
-  }
+  },
+  "id": "<%= p('elasticsearch_config.index_prefix') %>*",
+  "type":"index-pattern"
 }


### PR DESCRIPTION
## Changes Proposed

- Copies the pattern the opensearch bosh release uses to assign id's to the index patterns.  Without this, every time the upload-kibana-objects, the list of index patterns is duplicated because the id is blank.
- Part of https://github.com/cloud-gov/deploy-logsearch/issues/203
-

## Security Considerations

No changes to security footprint, no new secrets
